### PR TITLE
Release 3.4.3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,7 +87,7 @@ jobs:
           CIBW_ENVIRONMENT: CHARSET_NORMALIZER_USE_MYPYC='1'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest -c {package} {package}/tests
-          CIBW_SKIP: pp*
+          CIBW_SKIP: "pp* cp31?t-*"
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,11 +52,11 @@ jobs:
         qemu: [ '' ]
         include:
           # Split ubuntu job for the sake of speed-up
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             qemu: aarch64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             qemu: ppc64le
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             qemu: s390x
     steps:
       - name: Checkout
@@ -94,42 +94,6 @@ jobs:
           name: dist-${{ matrix.os }}-${{ matrix.qemu }}
           path: ./wheelhouse/*.whl
 
-  checksum:
-    name: Compute hashes
-    runs-on: ubuntu-latest
-    needs:
-      - build-wheels
-      - universal-wheel
-    outputs:
-      hashes: ${{ steps.compute.outputs.hashes }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Download distributions
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          pattern: dist*
-          merge-multiple: true
-          path: dist
-      - name: Collected dists
-        run: |
-          tree dist
-      - name: Generate hashes
-        id: compute  #  needs.checksum.outputs.hashes
-        working-directory: ./dist
-        run: echo "hashes=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
-
-  provenance:
-    needs: checksum
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    with:
-      base64-subjects: ${{ needs.checksum.outputs.hashes }}
-      upload-assets: true
-      compile-generator: true
-
   deploy:
     name: 🚀 Deploy to PyPi
     runs-on: ubuntu-latest
@@ -137,7 +101,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    needs: provenance
+    needs:
+      - build-wheels
+      - universal-wheel
     environment:
       name: pypi
       url: https://pypi.org/project/charset-normalizer/
@@ -155,7 +121,52 @@ jobs:
         run: |
           tree dist
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      - name: Install Syft
+        run: |
+          curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
+          syft version
+      - name: Generate SBOMs
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          restore_from=""
+          restore_to=""
+
+          for pkg in dist/*.whl dist/*.tar.gz; do
+            original_pkg="$pkg"
+            original_base="$(basename -- "$original_pkg")"
+            out="dist/${original_base}.cdx.json"
+
+            if [[ "$original_pkg" == *.whl ]]; then
+              zip_pkg="${original_pkg%.whl}.zip"
+              zip_base="${original_base%.whl}.zip"
+              stem="${original_base%.whl}"
+
+              echo "Temporarily renaming ${original_base} -> ${zip_base}"
+              mv -- "$original_pkg" "$zip_pkg"
+              restore_from="$zip_pkg"
+              restore_to="$original_pkg"
+
+              echo "Generating SBOM for $original_base via $zip_base"
+              syft "file:$zip_pkg" -o cyclonedx-json > "$out"
+
+              tmp="$out.tmp"
+              jq --arg stem "$stem" '
+                (. | .. | objects | select(has("name")) | .name)
+                |= (if . == ($stem + ".zip") then $stem + ".whl" else . end)
+              ' "$out" > "$tmp" && mv "$tmp" "$out"
+
+              echo "Restoring ${zip_base} -> ${original_base}"
+              mv -- "$zip_pkg" "$original_pkg"
+              restore_from=""
+              restore_to=""
+            else
+              echo "Generating SBOM for $original_base"
+              syft "file:$original_pkg" -o cyclonedx-json > "$out"
+            fi
+          done
       - name: Upload dists to GitHub Release
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,8 @@ jobs:
       - pre_flight_check
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -141,6 +143,8 @@ jobs:
       url: https://pypi.org/project/charset-normalizer/
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Download distributions
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -44,6 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -71,6 +75,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -106,6 +112,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -122,6 +130,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -162,6 +172,8 @@ jobs:
       PYTHONIOENCODING: utf8  # only needed for Windows (console IO output encoding)
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -224,6 +236,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         include:
           - python-version: "3.7"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,9 +16,9 @@ permissions:
 
 on:
   push:
-    branches: [ "master", "2.1.x" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "2.1.x" ]
+    branches: [ "master" ]
   schedule:
     - cron: '39 1 * * 6'
 
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - mypy(c) is no longer a required dependency at build time if `CHARSET_NORMALIZER_USE_MYPYC` isn't set to `1`. (#595) (#583)
+- automatically lower confidence on small bytes samples that are not Unicode in `detect` output legacy function. (#391)
 
 ### Added
 - Custom build backend to overcome inability to mark mypy as an optional dependency in the build phase.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - sdist archive contained useless directories.
+- automatically fallback on valid UTF-16 or UTF-32 even if the md says it's noisy. (#633)
 
 ### Misc
 - SBOM are automatically published to the relevant GitHub release to comply with regulatory changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Misc
 - SBOM are automatically published to the relevant GitHub release to comply with regulatory changes.
   Each published wheel comes with its SBOM. We choose CycloneDX as the format.
+- Prebuilt optimized wheel are no longer distributed by default for CPython 3.7 due to a change in cibuildwheel.
 
 ## [3.4.2](https://github.com/Ousret/charset_normalizer/compare/3.4.1...3.4.2) (2025-05-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 All notable changes to charset-normalizer will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.4.3](https://github.com/Ousret/charset_normalizer/compare/3.4.2...3.4.3) (2025-08-08)
+
+### Changed
+- mypy(c) is no longer a required dependency at build time if `CHARSET_NORMALIZER_USE_MYPYC` isn't set to `1`. (#595) (#583)
+
+### Added
+- Custom build backend to overcome inability to mark mypy as an optional dependency in the build phase.
+- Support for Python 3.14
+
+### Fixed
+- sdist archive contained useless directories.
+
+### Misc
+- SBOM are automatically published to the relevant GitHub release to comply with regulatory changes.
+  Each published wheel comes with its SBOM. We choose CycloneDX as the format.
+
 ## [3.4.2](https://github.com/Ousret/charset_normalizer/compare/3.4.1...3.4.2) (2025-05-02)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to charset-normalizer will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [3.4.3](https://github.com/Ousret/charset_normalizer/compare/3.4.2...3.4.3) (2025-08-08)
+## [3.4.3](https://github.com/Ousret/charset_normalizer/compare/3.4.2...3.4.3) (2025-08-09)
 
 ### Changed
 - mypy(c) is no longer a required dependency at build time if `CHARSET_NORMALIZER_USE_MYPYC` isn't set to `1`. (#595) (#583)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,6 @@ recursive-include data *.md
 recursive-include data *.txt
 recursive-include docs *
 recursive-include tests *
+recursive-exclude .github/ *
+recursive-exclude __pycache__/ *
+global-exclude *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE README.md CHANGELOG.md src/charset_normalizer/py.typed dev-requirements.txt SECURITY.md noxfile.py
+include LICENSE README.md CHANGELOG.md src/charset_normalizer/py.typed dev-requirements.txt SECURITY.md noxfile.py _mypyc_hook/*.py
 recursive-include data *.md
 recursive-include data *.txt
 recursive-include docs *

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 <p align="center">
   <sup><i>Featured Packages</i></sup><br>
   <a href="https://github.com/jawah/niquests">
-   <img alt="Static Badge" src="https://img.shields.io/badge/Niquests-Best_HTTP_Client-cyan">
+   <img alt="Static Badge" src="https://img.shields.io/badge/Niquests-Most_Advanced_HTTP_Client-cyan">
   </a>
   <a href="https://github.com/jawah/wassima">
-   <img alt="Static Badge" src="https://img.shields.io/badge/Wassima-Certifi_Killer-cyan">
+   <img alt="Static Badge" src="https://img.shields.io/badge/Wassima-Certifi_Replacement-cyan">
   </a>
 </p>
 <p align="center">

--- a/_mypyc_hook/backend.py
+++ b/_mypyc_hook/backend.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+USE_MYPYC = os.getenv("CHARSET_NORMALIZER_USE_MYPYC", "0") == "1"
+MYPYC_SPEC = "mypy>=1.4.1,<=1.17.1"
+
+from setuptools import build_meta as _orig
+
+# Expose all the PEP 517 hooks from setuptools
+get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+build_wheel = _orig.build_wheel
+build_sdist = _orig.build_sdist
+
+if hasattr(_orig, "get_requires_for_build_editable"):
+    get_requires_for_build_editable = _orig.get_requires_for_build_editable
+if hasattr(_orig, "prepare_metadata_for_build_editable"):
+    prepare_metadata_for_build_editable = _orig.prepare_metadata_for_build_editable
+if hasattr(_orig, "build_editable"):
+    build_editable = _orig.build_editable
+
+
+# Override the build requirements function to conditionally add Cython
+def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) -> list[str]:
+    """Get the build requirements, conditionally adding Mypy(C)."""
+    requires = _orig.get_requires_for_build_wheel(config_settings)
+    if USE_MYPYC and MYPYC_SPEC not in requires:
+        requires = list(requires) if requires else []
+        requires.append(MYPYC_SPEC)
+    return requires

--- a/_mypyc_hook/backend.py
+++ b/_mypyc_hook/backend.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from setuptools import build_meta as _orig  # type: ignore[import-not-found]
+
 USE_MYPYC = os.getenv("CHARSET_NORMALIZER_USE_MYPYC", "0") == "1"
 MYPYC_SPEC = "mypy>=1.4.1,<=1.17.1"
 
-from setuptools import build_meta as _orig
-
 # Expose all the PEP 517 hooks from setuptools
-get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
 get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
 prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
 build_wheel = _orig.build_wheel
@@ -24,10 +23,12 @@ if hasattr(_orig, "build_editable"):
 
 
 # Override the build requirements function to conditionally add Cython
-def get_requires_for_build_wheel(config_settings: dict[str, Any] | None = None) -> list[str]:
+def get_requires_for_build_wheel(
+    config_settings: dict[str, Any] | None = None,
+) -> list[str]:
     """Get the build requirements, conditionally adding Mypy(C)."""
     requires = _orig.get_requires_for_build_wheel(config_settings)
     if USE_MYPYC and MYPYC_SPEC not in requires:
         requires = list(requires) if requires else []
         requires.append(MYPYC_SPEC)
-    return requires
+    return requires  # type: ignore[no-any-return]

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def test(session: nox.Session) -> None:
     test_impl(session)
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"])
 def test_mypyc(session: nox.Session) -> None:
     test_impl(session, True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,7 @@ backend-path = ["_mypyc_hook"]
 [project]
 name = "charset-normalizer"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-license-files = ["LICENSE"]
-license = "MIT"
+license = {text = "MIT"}
 keywords = ["encoding", "charset", "charset-detector", "detector", "normalization", "unicode", "chardet", "detect"]
 authors = [
   {name = "Ahmed R. TAHRI", email="tahri.ahmed@proton.me"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "mypy>=1.4.1,<=1.17.1"]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "backend"
+backend-path = ["_mypyc_hook"]
 
 [project]
 name = "charset-normalizer"
@@ -27,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "charset-normalizer"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-license = {text = "MIT"}
+license-files = ["LICENSE"]
+license = "MIT"
 keywords = ["encoding", "charset", "charset-detector", "detector", "normalization", "unicode", "chardet", "detect"]
 authors = [
   {name = "Ahmed R. TAHRI", email="tahri.ahmed@proton.me"},
@@ -16,7 +17,6 @@ maintainers = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,20 @@
 from __future__ import annotations
 
 import os
-import sys
 
 from setuptools import setup
 
 USE_MYPYC = False
 
-if len(sys.argv) > 1 and sys.argv[1] == "--use-mypyc":
-    sys.argv.pop(1)
-    USE_MYPYC = True
-elif os.getenv("CHARSET_NORMALIZER_USE_MYPYC", None) == "1":
+if os.getenv("CHARSET_NORMALIZER_USE_MYPYC", None) == "1":
     USE_MYPYC = True
 
-if USE_MYPYC:
+try:
     from mypyc.build import mypycify
+except ImportError:
+    mypycify = None  # type: ignore[assignment]
 
+if USE_MYPYC and mypycify is not None:
     MYPYC_MODULES = mypycify(
         [
             "src/charset_normalizer/md.py",

--- a/src/charset_normalizer/api.py
+++ b/src/charset_normalizer/api.py
@@ -369,14 +369,15 @@ def from_bytes(
             # Preparing those fallbacks in case we got nothing.
             if (
                 enable_fallback
-                and encoding_iana in ["ascii", "utf_8", specified_encoding]
+                and encoding_iana
+                in ["ascii", "utf_8", specified_encoding, "utf_16", "utf_32"]
                 and not lazy_str_hard_failure
             ):
                 fallback_entry = CharsetMatch(
                     sequences,
                     encoding_iana,
                     threshold,
-                    False,
+                    bom_or_sig_available,
                     [],
                     decoded_payload,
                     preemptive_declaration=specified_encoding,

--- a/src/charset_normalizer/legacy.py
+++ b/src/charset_normalizer/legacy.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from warnings import warn
 
 from .api import from_bytes
-from .constant import CHARDET_CORRESPONDENCE
+from .constant import CHARDET_CORRESPONDENCE, TOO_SMALL_SEQUENCE
 
 # TODO: remove this check when dropping Python 3.7 support
 if TYPE_CHECKING:
@@ -48,6 +48,22 @@ def detect(
     encoding = r.encoding if r is not None else None
     language = r.language if r is not None and r.language != "Unknown" else ""
     confidence = 1.0 - r.chaos if r is not None else None
+
+    # automatically lower confidence
+    # on small bytes samples.
+    # https://github.com/jawah/charset_normalizer/issues/391
+    if (
+        confidence is not None
+        and confidence >= 0.9
+        and encoding
+        not in {
+            "utf_8",
+            "ascii",
+        }
+        and r.bom is False  # type: ignore[union-attr]
+        and len(byte_str) < TOO_SMALL_SEQUENCE
+    ):
+        confidence -= 0.2
 
     # Note: CharsetNormalizer does not return 'UTF-8-SIG' as the sig get stripped in the detection/normalization process
     # but chardet does return 'utf-8-sig' and it is a valid codec name.

--- a/src/charset_normalizer/version.py
+++ b/src/charset_normalizer/version.py
@@ -4,5 +4,5 @@ Expose version
 
 from __future__ import annotations
 
-__version__ = "3.4.2"
+__version__ = "3.4.3"
 VERSION = __version__.split(".")

--- a/tests/test_detect_legacy.py
+++ b/tests/test_detect_legacy.py
@@ -41,3 +41,20 @@ class TestDetectLegacy(unittest.TestCase):
 
         with self.subTest("Verify that UTF-8-SIG is returned when using legacy detect"):
             self.assertEqual(r["encoding"], "UTF-8-SIG")
+
+    def test_small_payload_confidence_altered(self):
+
+        with self.subTest("Unicode should yield 1. confidence even on small bytes string"):
+            r = detect("#表 10-1 クラスタ設定".encode("utf_16"))
+
+            self.assertTrue(r["confidence"] == 1.0)
+
+        with self.subTest("ShiftJis should not yield 1. confidence on small bytes string"):
+            r = detect("#表 10-1 クラスタ設定".encode("cp932"))
+
+            self.assertTrue(r["confidence"] < 1.0)
+
+        with self.subTest("ShiftJis should yield 1. confidence on sufficient bytes string"):
+            r = detect("#表 10-1 クラスタ設定　…　リソース同居制約".encode("cp932"))
+
+            self.assertTrue(r["confidence"] == 1.0)


### PR DESCRIPTION
## [3.4.3](https://github.com/Ousret/charset_normalizer/compare/3.4.2...3.4.3) (2025-08-09)

### Changed
- mypy(c) is no longer a required dependency at build time if `CHARSET_NORMALIZER_USE_MYPYC` isn't set to `1`. (#595) (#583)
- automatically lower confidence on small bytes samples that are not Unicode in `detect` output legacy function. (#391)

### Added
- Custom build backend to overcome inability to mark mypy as an optional dependency in the build phase.
- Support for Python 3.14

### Fixed
- sdist archive contained useless directories.
- automatically fallback on valid UTF-16 or UTF-32 even if the md says it's noisy. (#633)

### Misc
- SBOM are automatically published to the relevant GitHub release to comply with regulatory changes.
  Each published wheel comes with its SBOM. We choose CycloneDX as the format.
- Prebuilt optimized wheel are no longer distributed by default for CPython 3.7 due to a change in cibuildwheel.
