### PR TITLE
Allow builds with setuptools 84

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68,<83.1"]
+requires = ["setuptools>=68,<84.1"]
 build-backend = "backend"
 backend-path = ["_build_hook"]
 


### PR DESCRIPTION
## Summary

- relax the build-system setuptools constraint from `<83.1` to `<84.1`
- allow downstream packagers to build charset-normalizer with setuptools 84.x while preserving the existing next-minor upper-bound convention

Closes #793.

## Validation

- built both sdist and wheel with setuptools 84.0.0 (`python -m build --no-isolation`)
- `197 passed, 11 subtests passed` on Python 3.12
- `nox -s lint`
- `nox -s coverage` — 98.323% (469/477 files)

The first coverage attempt only hit the Windows GBK console encoding on emoji output; rerunning the unchanged test with `PYTHONUTF8=1` completed successfully.