### PR TITLE
Release 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to charset-normalizer will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.5.1](https://github.com/Ousret/charset_normalizer/compare/3.5.0...3.5.1) (2026-08-15)
+
+### Changed
+- Raised upper bound of setuptools to v84 (#794)
+- Cache performance access optimization for our CharInfo struct (prebuilt only).
+
+### Fixed
+- No longer decoding large content when the noise detector output give a high entropy.
+  Only impacted large content input >1M bytes.
+
 ## [3.5.0](https://github.com/Ousret/charset_normalizer/compare/3.4.9...3.5.0) (2026-08-12)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ This project offers you an alternative to **Universal Charset Encoding Detector*
 | Feature                                          | [Chardet](https://github.com/chardet/chardet) |                                       Charset Normalizer                                        | [cChardet](https://github.com/PyYoshi/cChardet) |
 |--------------------------------------------------|:---------------------------------------------:|:-----------------------------------------------------------------------------------------------:|:-----------------------------------------------:|
 | `Fast`                                           |                       ✅                       |                                                ✅                                                |                        ✅                        |
+| `Fast on large content (uncapped)`               |                       ❌                       |                                                ✅                                                |                        ❌                        |
 | `Universal`[^1]                                  |                       ❌                       |                                                ✅                                                |                        ❌                        |
 | `Reliable` **without** distinguishable standards |                       ✅                       |                                                ✅                                                |                        ✅                        |
 | `Reliable` **with** distinguishable standards    |                       ✅                       |                                                ✅                                                |                        ✅                        |
 | `License`                                        |           _0BSD_[^2]<br>_disputed_            |                                               MIT                                               |            MPL-1.1<br>_restrictive_             |
 | `Native Python`                                  |                       ✅                       |                                                ✅                                                |                        ❌                        |
 | `Detect spoken language`                         |                       ✅                       |                                                ✅                                                |                       N/A                       |
-| `UnicodeDecodeError Safety`                      |                       ✅                       |                                                ✅                                                |                        ❌                        |
-| `Whl Size`                                       |                   ~1024 kB                    |                                             ~250 kB                                             |                     ~200 kB                     |
+| `UnicodeDecodeError Safety`                      |                       ❌                       |                                                ✅                                                |                        ❌                        |
+| `Whl Size`                                       |                   ~1200 kB                    |                                             ~250 kB                                             |                     ~200 kB                     |
 | `Supported Encoding`                             |                      99                       | [99](https://charset-normalizer.readthedocs.io/en/latest/user/support.html#supported-encodings) |                       40                        |
 | `Can register custom encoding`                   |                       ❌                       |                                                ✅                                                |                        ❌                        |
 
@@ -54,30 +55,42 @@ This project offers you an alternative to **Universal Charset Encoding Detector*
 </p>
 
 [^1]: They are clearly using specific code for a specific encoding even if covering most of them.
-[^2]: Chardet 7 replaced the historical LGPL-licensed implementation with an AI-assisted rewrite, initially distributed under MIT and later under 0BSD. The original author [contests](https://github.com/chardet/chardet/issues/327) that the rewrite was sufficiently independent to permit relicensing, while Chardet's maintainer maintains that it is a new, non-derivative implementation. A separate [discussion](https://github.com/chardet/chardet/issues/334) raises questions about copyright ownership and licensing of substantially AI-generated code. Neither unresolved question is presented here as settled law. The concern is broader than whether ideas, APIs, or observable behavior are copyrightable. Independent implementations are essential to open-source competition. The ethical question is whether a maintainer with extensive access to a reciprocal project's source, architecture, tests, behavior, community, and reputation can use an LLM to recreate the same product under the same package identity, then treat the generated implementation as a provenance reset that extinguishes the project's reciprocal licensing obligations and contributor expectations. Responsible AI use in open source requires more than producing text that differs from the historical source: it requires transparent provenance, respect for project lineage, meaningful attribution, accountable human review, and consideration for the social agreement under which earlier contributors participated. If automated rewriting becomes an accepted way to retain a project's name, users, and accumulated reputation while discarding its reciprocal license, it risks weakening the trust and incentives on which FOSS depends. Early Chardet 7.x development and evaluation also incorporated files originating from charset-normalizer's test corpus. Results measured on data that influenced implementation or model development are not independent validation. Charset-normalizer has been MIT-licensed since inception and originates from a continuous human-designed, encoding-agnostic project history. AI assistance may be used, but every proposed change remains subject to maintainer review, adjustment, testing, and accountability; AI is an engineering aid, not a mechanism for erasing provenance or project lineage.
+[^2]: Chardet 7 replaced the historical LGPL-licensed implementation with an AI-assisted rewrite, initially distributed under MIT and later under 0BSD. The original author [contests](https://github.com/chardet/chardet/issues/327) that the rewrite was sufficiently independent to permit relicensing, while Chardet's maintainer maintains that it is a new, non-derivative implementation. A separate [discussion](https://github.com/chardet/chardet/issues/334) raises questions about copyright ownership and licensing of substantially AI-generated code. Neither unresolved question is presented here as settled law. The concern is broader than whether ideas, APIs, or observable behavior are copyrightable. Independent implementations are essential to open-source competition. The ethical question is whether a maintainer with extensive access to a reciprocal project's source, architecture, tests, behavior, community, and reputation can use an LLM to recreate the same product under the same package identity, then treat the generated implementation as a provenance reset that extinguishes the project's reciprocal licensing obligations and contributor expectations. Responsible AI use in open source requires more than producing text that differs from the historical source: it requires transparent provenance, respect for project lineage, meaningful attribution, accountable human review, and consideration for the social agreement under which earlier contributors participated. If automated rewriting becomes an accepted way to retain a project's name, users, and accumulated reputation while discarding its reciprocal license, it risks weakening the trust and incentives on which FOSS depends. Early Chardet 7.x development and evaluation also incorporated files originating from charset-normalizer's test corpus. Results measured on data that influenced implementation or model development are not independent validation. Charset-normalizer has been MIT-licensed since inception and originates from a continuous human-designed, encoding-agnostic project history. AI assistance may be used, but every proposed change remains subject to maintainer review, adjustment, testing, and accountability; AI is an engineering aid, not a mechanism for erasing provenance or project lineage. An attentive eye will see that some aspects lead by us are magically found in Chardet.
 
 ## ⚡ Performance
 
-This package offer similar performances against Chardet but faster in p99. Here are some numbers.
+This package offer similar performances in general against Chardet. Expect 10X faster with large contents when you uncap Chardet max_bytes default assumption.
 
-| Package                                           | Accuracy | Mean per file (ms) |
-|---------------------------------------------------|:--------:|:------------------:|
-| [chardet 7.5](https://github.com/chardet/chardet) |   99 %   |       0.5 ms       |
-| charset-normalizer                                |   98 %   |       0.6 ms       |
+| Package            | Accuracy |  Mean per file (ms)   |
+|--------------------|:--------:|:---------------------:|
+| Chardet            |   99 %   | 0.4 ms[^4] 0.6 ms[^5] |
+| charset-normalizer |   98 %   |        0.4 ms         |
+| cchardet[^3]       |   94 %   |        0.6 ms         |
 
-| Package                                           | 99th percentile | 95th percentile | 50th percentile |
-|---------------------------------------------------|:---------------:|:---------------:|:---------------:|
-| [chardet 7.5](https://github.com/chardet/chardet) |     4.5 ms      |     1.5 ms      |     0.2 ms      |
-| charset-normalizer                                |     3.9 ms      |     1.9 ms      |     0.3 ms      |
+_Well, sub-ms detectors made them extremely discrete in the overall runtime.
+Competitors can still win individual measurements, especially capped Chardet on
+small-file median latency. But when performance, accuracy, binary handling, validation
+strength, portability, and maintainability are considered together, charset-normalizer
+is the stronger package._
 
-_updated as of August 2026 using CPython 3.12, Charset-Normalizer 3.5, and Chardet 7.5 inside a (libc Debian) container. The host CPU is a 13th gen Intel mobile CPU._
+| Package            |   99th percentile    | 95th percentile | 50th percentile |
+|--------------------|:--------------------:|:---------------:|:---------------:|
+| Chardet            | 2.5 ms[^4] 4.2ms[^5] |      1 ms       |     0.2 ms      |
+| charset-normalizer |        2.7 ms        |     1.5 ms      |     0.2 ms      |
+| cchardet           |        2.7 ms        |      2 ms       |     0.3 ms      |
+
+_updated as of August 2026 using CPython 3.12, Charset-Normalizer 3.5.1, and Chardet 7.5 inside a (libc Debian) container. The host CPU is a 13th gen Intel mobile CPU. We'll no longer update regularly those since the sub-ms changes aren't meaningful to anyone anymore._
 
 > Stats are generated using 477 files using default parameters. More details on used files, see GHA workflows.
 > And yes, these results might change at any time. The dataset can be updated to include more files.
 > The actual delays heavily depends on your CPU capabilities. The factors should remain the same.
 > Chardet claims on his documentation to have a greater accuracy than us based on the dataset they trained Chardet on(...)
-> Well, it's normal, the opposite would have been worrying. Whereas charset-normalizer don't train on anything, our solution
-> is based on a completely different algorithm, still heuristic through, it does not need weights across every encoding tables.
+> Whereas charset-normalizer don't train on anything, our solution is based on a completely different algorithm, still heuristic
+> through, it does not need weights across every encoding tables.
+
+[^3]: cchardet main repository/package was discontinued. we're relying on a known fork namely faust-cchardet. the idea remained the same: uchardet bindings.
+[^4]: Chardet does not feed the complete body but rather a limited part of it, because the algorithm doesn't scale properly with larger samples. Feeding the whole content slow things to 0.8 ms (from the 0.5ms avg). While we do not skip content in order for us to guarantee a usable result each and every time. We attempted to feed a 272 MiB UTF-8 (Reddit archive on comments/posts) file in Chardet uncapped and waited 3.4s while Charset-Normalizer took 0.3s, this is a 10-fold speedup.
+[^5]: Uncapped max_bytes (no truncating of content)
 
 ## ✨ Installation
 

--- a/docs/community/faq.rst
+++ b/docs/community/faq.rst
@@ -37,12 +37,7 @@ Is it backward-compatible with Chardet?
 ---------------------------------------
 
 If you use the legacy `detect` function,
-Then this change is mostly backward-compatible, exception of a thing:
-
-- This new library support way more code pages (x3) than its counterpart Chardet.
-- Based on the 30-ich charsets that Chardet support, expect roughly 80% BC results
-
-We do not guarantee this BC exact percentage through time. May vary but not by much.
+Then this change is mostly backward-compatible.
 
 Isn't it the same as Chardet?
 -----------------------------
@@ -56,3 +51,7 @@ rudimentary detection.
 
 Any code page supported by your cPython is supported by charset-normalizer! It is that simple, no need to update the
 library. It is as generic as we could do.
+
+Chardet v7, through the magic AI rewrite, decided to leverage some aspect that distance itself from the "pure" statistical
+algorithm it was before. They now implement similar guidance as we did since inception like (i.e. what they identify as)
+"Escape Sequences"+"Binary Detection"+"Markup Charset".

--- a/docs/community/why_migrate.rst
+++ b/docs/community/why_migrate.rst
@@ -8,7 +8,9 @@ There is so many reason to migrate your current project. Here are some of them:
 - Have the backward compatible function ``detect`` that come from Chardet.
 - It is, for the first time, really universal! As there is no specific probe per charset.
 - The package size is X2~X3 lower than Chardet's (7.0)! (Depends on your arch/OS)
-- Faster than Chardet in p99 latency.
+- 2X Faster than Chardet in p99 latency. 10X faster with large content. When Chardet is uncapped (i.e. max_bytes).
+- Faster than older C/C++ bind of uchardet. There is no more need to use those wrapper.
+- Truly protect you from decoding error! E.g. Never get UnicodeDecodeError, ever!
 - Propose much more options/public kwargs to tweak the detection as you sees fit!
 
 And much more..! What are you waiting for? Upgrade now and give us a feedback. (Even if negative)

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -179,5 +179,3 @@ Incomplete Sequence / Stream
 It is not (yet) officially supported. If you feed an incomplete byte sequence (eg. truncated multi-byte sequence) the detector will
 most likely fail to return a proper result.
 If you are purposely feeding part of your payload for performance concerns, you may stop doing it as this package is fairly optimized.
-
-We are working on a dedicated way to handle streams.

--- a/src/charset_normalizer/api.py
+++ b/src/charset_normalizer/api.py
@@ -467,12 +467,16 @@ def from_bytes(
             early_stop_count = max_chunk_gave_up
             lazy_str_hard_failure = True
 
-        # We might want to check the sequence again with the whole content
-        # Only if initial MD tests passes
+        mean_mess_ratio: float = sum(md_ratios) / len(md_ratios) if md_ratios else 0.0
+
+        # We might want to check the sequence again with the whole content,
+        # but only if initial MD tests passed.
         if (
             not lazy_str_hard_failure
             and is_too_large_sequence
             and not is_multi_byte_decoder
+            and mean_mess_ratio < threshold
+            and early_stop_count < max_chunk_gave_up
         ):
             try:
                 sequences[int(50e3) :].decode(encoding_iana, errors="strict")
@@ -486,7 +490,6 @@ def from_bytes(
                 tested_but_hard_failure.append(encoding_iana)
                 continue
 
-        mean_mess_ratio: float = sum(md_ratios) / len(md_ratios) if md_ratios else 0.0
         if mean_mess_ratio >= threshold or early_stop_count >= max_chunk_gave_up:
             tested_but_soft_failure.append(encoding_iana)
             if encoding_iana in IANA_SUPPORTED_SIMILAR:

--- a/src/charset_normalizer/md.pyx
+++ b/src/charset_normalizer/md.pyx
@@ -61,6 +61,12 @@ cdef int _LIGATURE_MASK = _LIGATURE
 cdef int _SUPERSCRIPT_MASK = _SUPERSCRIPT
 cdef int _SENTENCE_OPEN_PUNCTUATION_MASK = _SENTENCE_OPEN_PUNCTUATION
 
+cdef enum:
+    UNICODE_PAGE_SHIFT = 8
+    UNICODE_PAGE_SIZE = 256
+    UNICODE_PAGE_MASK = 255
+    UNICODE_PAGE_COUNT = 4352
+
 
 cdef class CharInfo:
     """Pre-computed character properties shared across all detectors."""
@@ -190,22 +196,29 @@ cdef class CharInfo:
         self.sep = is_separator(character)
 
 
-@lru_cache(maxsize=None)
 def _char_info(str character):
     """Build and cache character information for the public string API."""
-    cdef CharInfo info = CharInfo(character)
-    _CHAR_INFO_BY_CODEPOINT[<uint32_t>ord(character)] = info
-    return info
+    return _char_info_from_codepoint(ord(character))
 
 
 _ASCII_CHAR_INFO = [CharInfo(chr(codepoint)) for codepoint in range(128)]
-_CHAR_INFO_BY_CODEPOINT = {}
+_CHAR_INFO_PAGES = [None] * UNICODE_PAGE_COUNT
 
 
 cdef CharInfo _char_info_from_codepoint(Py_UCS4 codepoint):
-    cdef object info = _CHAR_INFO_BY_CODEPOINT.get(<uint32_t>codepoint)
+    cdef Py_ssize_t page_index = (<Py_ssize_t>codepoint) >> UNICODE_PAGE_SHIFT
+    cdef Py_ssize_t slot_index = (<Py_ssize_t>codepoint) & UNICODE_PAGE_MASK
+    cdef object page = _CHAR_INFO_PAGES[page_index]
+    cdef object info
+
+    if page is None:
+        page = [None] * UNICODE_PAGE_SIZE
+        _CHAR_INFO_PAGES[page_index] = page
+
+    info = (<list>page)[slot_index]
     if info is None:
-        info = _char_info(chr(codepoint))
+        info = CharInfo(chr(codepoint))
+        (<list>page)[slot_index] = info
     return <CharInfo>info
 
 

--- a/src/charset_normalizer/version.py
+++ b/src/charset_normalizer/version.py
@@ -4,5 +4,5 @@ Expose version
 
 from __future__ import annotations
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"
 VERSION = __version__.split(".")


### PR DESCRIPTION
## [3.5.1](https://github.com/Ousret/charset_normalizer/compare/3.5.0...3.5.1) (2026-08-15)

### Changed
- Raised upper bound of setuptools to v84 (#794)
- Cache performance access optimization for our CharInfo struct (prebuilt only).

### Fixed
- No longer decoding large content when the noise detector output give a high entropy.
  Only impacted large content input >1M bytes.
